### PR TITLE
Fix key derivation when path is given as string

### DIFF
--- a/packages/bitcore-lib/lib/hdprivatekey.js
+++ b/packages/bitcore-lib/lib/hdprivatekey.js
@@ -74,7 +74,9 @@ function HDPrivateKey(arg) {
 HDPrivateKey.isValidPath = function(arg, hardened) {
   if (_.isString(arg)) {
     var indexes = HDPrivateKey._getDerivationIndexes(arg);
-    return indexes !== null && _.every(indexes, HDPrivateKey.isValidPath);
+    return indexes !== null && _.every(indexes, function (index) {
+      return HDPrivateKey.isValidPath(index, hardened);
+    });
   }
 
   if (_.isNumber(arg)) {
@@ -116,7 +118,7 @@ HDPrivateKey._getDerivationIndexes = function(path) {
       return NaN;
     }
     var index = +step; // cast to number
-    if (isHardened) {
+    if (index < HDPrivateKey.Hardened && isHardened === true) {
       index += HDPrivateKey.Hardened;
     }
 


### PR DESCRIPTION
As described in this issue: https://github.com/bitpay/bitcore/issues/3358

This PR fixes the derivation issues when trying to create a key with a string-typed derivation path such as `m/0'/1/2/3`